### PR TITLE
Merge fix/normalize-one-projection into master

### DIFF
--- a/.idea/php-api-common.iml
+++ b/.idea/php-api-common.iml
@@ -2,7 +2,9 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="DaybreakStudios\RestApiCommon\" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/dbstudios/doctrine-entities" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/dbstudios/doctrine-query-document" />

--- a/src/Controller/AbstractApiController.php
+++ b/src/Controller/AbstractApiController.php
@@ -239,7 +239,7 @@
 			if (is_array($data))
 				$data = $this->normalizeMany($data, $projection);
 			else if ($data instanceof EntityInterface)
-				$data = $this->normalizeOne($data, $projection);
+				$data = $projection->filter($this->normalizeOne($data, $projection));
 
 			return $this->responder->createResponse($data);
 		}


### PR DESCRIPTION
## Changelog
- Fixed a bug wherein `Projection::filter()` was not being called when normalizing a single entity object in `AbstractApiController::respond()`.