### PR TITLE
Merge feature/new-projection-interface into main

### DIFF
--- a/.idea/phpunit.xml
+++ b/.idea/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PHPUnit">
+    <option name="directories">
+      <list>
+        <option value="$PROJECT_DIR$/tests" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/composer.lock
+++ b/composer.lock
@@ -232,16 +232,16 @@
         },
         {
             "name": "dbstudios/doctrine-query-document",
-            "version": "1.5.1",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/LartTyler/doctrine-query-document.git",
-                "reference": "6f2634ee9ac04d61b148ceffc03fc65441808398"
+                "reference": "e26edd313168ccdf7d131b52982c8cdc5cdd6101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/LartTyler/doctrine-query-document/zipball/6f2634ee9ac04d61b148ceffc03fc65441808398",
-                "reference": "6f2634ee9ac04d61b148ceffc03fc65441808398",
+                "url": "https://api.github.com/repos/LartTyler/doctrine-query-document/zipball/e26edd313168ccdf7d131b52982c8cdc5cdd6101",
+                "reference": "e26edd313168ccdf7d131b52982c8cdc5cdd6101",
                 "shasum": ""
             },
             "require": {
@@ -274,9 +274,9 @@
             "description": "Allows building Doctrine queries using MongoDB-style query documents",
             "support": {
                 "issues": "https://github.com/LartTyler/doctrine-query-document/issues",
-                "source": "https://github.com/LartTyler/doctrine-query-document/tree/1.5.1"
+                "source": "https://github.com/LartTyler/doctrine-query-document/tree/1.8.0"
             },
-            "time": "2021-06-18T15:56:42+00:00"
+            "time": "2023-08-11T18:58:03+00:00"
         },
         {
             "name": "dbstudios/entity-transformers",
@@ -6737,5 +6737,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Controller/AbstractApiController.php
+++ b/src/Controller/AbstractApiController.php
@@ -2,6 +2,7 @@
 	namespace DaybreakStudios\RestApiCommon\Controller;
 
 	use DaybreakStudios\DoctrineQueryDocument\Projection\Projection;
+	use DaybreakStudios\DoctrineQueryDocument\Projection\ProjectionInterface;
 	use DaybreakStudios\DoctrineQueryDocument\QueryManagerInterface;
 	use DaybreakStudios\RestApiCommon\Error\ApiErrorInterface;
 	use DaybreakStudios\RestApiCommon\Error\Errors\ApiController\GenericApiError;
@@ -353,13 +354,7 @@
 			return $this->responder->createResponse($data);
 		}
 
-		/**
-		 * @param array      $data
-		 * @param Projection $projection
-		 *
-		 * @return array
-		 */
-		protected function normalizeMany(array $data, Projection $projection): array {
+		protected function normalizeMany(array $data, ProjectionInterface $projection): array {
 			$normalized = [];
 
 			foreach ($data as $item) {
@@ -389,11 +384,5 @@
 			return $this->respond($request, $error);
 		}
 
-		/**
-		 * @param EntityInterface $entity
-		 * @param Projection      $projection
-		 *
-		 * @return array
-		 */
-		protected abstract function normalizeOne(EntityInterface $entity, Projection $projection): array;
+		protected abstract function normalizeOne(EntityInterface $entity, ProjectionInterface $projection): array;
 	}


### PR DESCRIPTION
## What's Changed
- **Breaking:** Updated `AbstractApiController` to use `ProjectionInterface` for `normalizeOne()` and `normalizeMany()` methods.
    - Note: The concrete `Projection` class is still used internally when parsing projections from the request.